### PR TITLE
Fix double dollar sign on search page.

### DIFF
--- a/search.html
+++ b/search.html
@@ -40,7 +40,7 @@
                     {{=item.appName}}
                     <div class="command">
                       <div class="sh">
-                        <code>$ brew cask install {{=item.caskName}}</code>
+                        <code>brew cask install {{=item.caskName}}</code>
                       </div>
                     </div>
                 </div>


### PR DESCRIPTION
The search results currently show two dollar signs, like so:

![Screencap](https://monosnap.com/file/kHFbbpd6BTuaSMjMcLbovmuxNs39lZ.png)

This PR fixes this problem. Result:

![Screencap](https://monosnap.com/file/QqPevxgA0lb0l6mixb1GtjHOcWmjem.png)