### PR TITLE
Search: add casks loading handle

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -29,6 +29,7 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   var loadCasks = function loadCasks(data) {
+    $('#search-input').attr('disabled', false).focus();
     caskList = pre.indexCaskData(data)
     if (queryURL) searchFromURL(queryURL);
   }

--- a/search.html
+++ b/search.html
@@ -24,7 +24,7 @@
 
     <div id="search-page">
         <form class="search-bar column-main spacing">
-            <input type = "text" id = "search-input" placeholder = "search" autocomplete = "off" autofocus class = "delta highlight-bg">
+            <input type = "text" id = "search-input" placeholder = "search" autocomplete = "off" disabled class = "delta highlight-bg">
         </form>
 
         <div id="search-view" class="column-main">


### PR DESCRIPTION
  - setting search input default disabled
  - search input autofocus when casks list API responsed

No loading handle will search failed.
![image](https://cloud.githubusercontent.com/assets/4191668/16694052/ccd19476-456a-11e6-9a78-7a5a8cf7ea83.png)
