### PR TITLE
Fix missing fonts

### DIFF
--- a/css/cask.css
+++ b/css/cask.css
@@ -65,7 +65,7 @@ input::-moz-focus-inner {
 }
 
 body {
-  font-family: 'museo-sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Roboto", sans-serif;
   font-size: 100%;
   font-weight: 500;
   line-height: 1.5;
@@ -82,7 +82,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .title {
-  font-family: 'museo-slab';
   font-weight: 700;
 }
 


### PR DESCRIPTION
Removes reference to Museo Slab in title (will now inherit Klinic Slab) and changes the body font family, removing `museo-sans` and matching that of http://brew.sh