### PR TITLE
Adjusted how contributions are counted

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
                 <div class="summary delta">
                     <p>Homebrew Cask extends <a href="http://brew.sh">Homebrew</a> and brings its elegance, simplicity, and speed to macOS applications and large binaries alike.</p>
                     <p>It only takes <span class="cyan">1 line</span> in your shell
-                    to reach <span class="cyan"><span id="n-cask">2100</span> Casks</span>
-                    maintained by <span class="cyan"><span id="n-contrib">1000</span> contributors</span>.</p>
+                    to reach <span class="cyan"><span id="n-cask">3500</span> Casks</span>
+                    maintained by <span class="cyan"><span id="n-contrib">2500</span> contributors</span>.</p>
                 </div>
             </div>
 

--- a/js/pre.js
+++ b/js/pre.js
@@ -34,7 +34,7 @@
   }
 
   exports.commitTreeURL = commitTreeURL;
-  exports.contribURL = "https://api.github.com/repos/caskroom/homebrew-cask/contributors?per_page=1";
+  exports.contribURL = "https://api.github.com/repos/caskroom/homebrew-cask/contributors?per_page=1&anon=1";
   exports.retrieveCaskData = retrieveCaskData;
   exports.isCaskFile = isCaskFile;
   exports.indexCaskData = indexCaskData;


### PR DESCRIPTION
So, not sure if this is something that's being looked for but...

I noticed that the number of contributors being returned was significantly smaller than the count Github shows (427 instead of 3,491) so I updated it, adding anon=1 to the parameters. Currently my copy shows the count as being 4,395 which is now higher than the Github count, so take it as you will.

I also updated the default values to 3,500 and 2,500 respectively.